### PR TITLE
RFR: 8265667: Add README.md and CONTRIBUTING.md to FX 11-dev/rt repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+Contributing to OpenJFX 11 Updates
+==================================
+
+The OpenJFX 11 Updates repository is _not_ accepting new contributions. If you are looking to contribute to OpenJFX, please visit [openjdk/jfx](https://github.com/openjdk/jfx) instead.
+
+Important bug fixes that have already been fixed in the mainline can be backported with approval. New fixes should first go into the mainline, and then can be considered for backporting. Approval from one of the project leads is required prior to integrating the fix.
+
+To backport a fix, you need to import the patch from mainline into a branch of your personal fork of this repo. Then, you can create the pull request. We strongly recommend creating a backport-style pull request, by creating the PR with the title:
+
+```
+Backport LONG-COMMIT-HASH
+```
+
+where `LONG-COMMIT-HASH` is the long (40 char) commit hash of the fix as found in the main jfx repo. The Skara tooling will then note that it is a backport, and replace the title with the correct issue title.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ The OpenJFX 11 Updates repository is _not_ accepting new contributions. If you a
 
 Important bug fixes that have already been fixed in the mainline can be backported with approval. New fixes should first go into the mainline, and then can be considered for backporting. Approval from one of the project leads is required prior to integrating the fix.
 
-To backport a fix, you need to import the patch from mainline into a branch of your personal fork of this repo. Then, you will create a [Backport Pull Request](https://wiki.openjdk.java.net/display/SKARA/Backports#Backports-BackportPullRequests), by creating the PR with the title:
+To backport a fix, import the patch from the jfx mainline into a branch of your personal fork of this repo. Then, create a [Backport Pull Request](https://wiki.openjdk.java.net/display/SKARA/Backports#Backports-BackportPullRequests), by creating the PR with the title:
 
 ```
 Backport LONG-COMMIT-HASH

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ The OpenJFX 11 Updates repository is _not_ accepting new contributions. If you a
 
 Important bug fixes that have already been fixed in the mainline can be backported with approval. New fixes should first go into the mainline, and then can be considered for backporting. Approval from one of the project leads is required prior to integrating the fix.
 
-To backport a fix, you need to import the patch from mainline into a branch of your personal fork of this repo. Then, you can create the pull request. We strongly recommend creating a backport-style pull request, by creating the PR with the title:
+To backport a fix, you need to import the patch from mainline into a branch of your personal fork of this repo. Then, you will create a [Backport Pull Request](https://wiki.openjdk.java.net/display/SKARA/Backports#Backports-BackportPullRequests), by creating the PR with the title:
 
 ```
 Backport LONG-COMMIT-HASH

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# OpenJFX 11 Updates
+
+This repository has the source code for OpenJFX 11 Update Releases. The main repository for OpenJFX development is [https://github.com/openjdk/jfx](https://github.com/openjdk/jfx).
+
+
+## Contributing
+
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on submitting pull requests to OpenJFX 11. If you are looking to contribute to OpenJFX, please visit [openjdk/jfx](https://github.com/openjdk/jfx) instead.

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ This repository has the source code for OpenJFX 11 Update Releases. The main rep
 
 ## Contributing
 
-Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on submitting pull requests to OpenJFX 11. If you are looking to contribute to OpenJFX, please visit [openjdk/jfx](https://github.com/openjdk/jfx) instead.
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on submitting backport pull requests to OpenJFX 11. If you are looking to contribute to OpenJFX, please visit [openjdk/jfx](https://github.com/openjdk/jfx) instead.


### PR DESCRIPTION
This Draft PR is to allow review of the proposed README.md and CONTRIBUTING.md files for jfx 11 updates. See the following JBS bug:

[JDK-8265667](https://bugs.openjdk.java.net/browse/JDK-8265667): Add README.md and CONTRIBUTING.md to FX 11-dev/rt repo

NOTE: this PR will not be integrated. Instead, once approved, it will be pushed to the [openjfx/11-dev/rt](https://hg.openjdk.java.net/openjfx/11-dev/rt) HG repo.