### PR TITLE
WIP: 8342453: Remove calls to doPrivileged in javafx.graphics/com.sun.javafx.tk

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -520,10 +520,8 @@ public abstract class Toolkit {
         }
     }
 
-    @SuppressWarnings("removal")
     public void notifyWindowListeners(final List<TKStage> windows) {
-        for (Map.Entry<TKListener,AccessControlContext> entry : toolkitListeners.entrySet()) {
-            final TKListener listener = entry.getKey();
+        for (TKListener listener : toolkitListeners.keySet()) {
             listener.changedTopLevelWindows(windows);
         }
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -57,7 +57,6 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.security.AccessControlContext;
 import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -102,8 +101,7 @@ public abstract class Toolkit {
 
     private static final Map gradientMap = new WeakHashMap();
 
-    @SuppressWarnings("removal")
-    private static final boolean verbose = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("javafx.verbose"));
+    private static final boolean verbose = Boolean.getBoolean("javafx.verbose");
 
     private static final String[] msLibNames = {
         "api-ms-win-core-console-l1-1-0",
@@ -200,13 +198,9 @@ public abstract class Toolkit {
             return TOOLKIT;
         }
 
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
-            // Get the javafx.version and javafx.runtime.version from a preconstructed
-            // java class, VersionInfo, created at build time.
-            VersionInfo.setupSystemProperties();
-            return null;
-        });
+        // Get the javafx.version and javafx.runtime.version from a preconstructed
+        // java class, VersionInfo, created at build time.
+        VersionInfo.setupSystemProperties();
 
         // Load required Microsoft runtime DLLs on Windows platforms
         if (PlatformUtil.isWindows()) {
@@ -216,9 +210,6 @@ public abstract class Toolkit {
         boolean userSpecifiedToolkit = true;
 
         // Check a system property to see if there is a specific toolkit to use.
-        // This is not a doPriviledged check so that applications running
-        // with a security manager cannot use this unless they have permission
-        // to read system properties.
         String forcedToolkit = null;
         try {
             forcedToolkit = System.getProperty("javafx.toolkit");
@@ -397,10 +388,7 @@ public abstract class Toolkit {
             throw new IllegalStateException("Invalid AccessControlContext");
         }
 
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            listener.pulse();
-            return null;
-        }, acc);
+        listener.pulse();
     }
 
     public void firePulse() {
@@ -536,15 +524,7 @@ public abstract class Toolkit {
     public void notifyWindowListeners(final List<TKStage> windows) {
         for (Map.Entry<TKListener,AccessControlContext> entry : toolkitListeners.entrySet()) {
             final TKListener listener = entry.getKey();
-            final AccessControlContext acc = entry.getValue();
-            if (acc == null) {
-                throw new IllegalStateException("Invalid AccessControlContext");
-            }
-
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                listener.changedTopLevelWindows(windows);
-                return null;
-            }, acc);
+            listener.changedTopLevelWindows(windows);
         }
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/EmbeddedScene.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/EmbeddedScene.java
@@ -36,8 +36,6 @@ import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.image.PixelFormat;
 import java.nio.IntBuffer;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import com.sun.javafx.cursor.CursorFrame;
 import com.sun.javafx.embed.AbstractEvents;
 import com.sun.javafx.embed.EmbeddedSceneDTInterface;
@@ -205,16 +203,12 @@ final class EmbeddedScene extends GlassScene implements EmbeddedSceneInterface {
         return false;
     }
 
-    @SuppressWarnings("removal")
     @Override
     public void setSize(final int width, final int height) {
         Platform.runLater(() -> {
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                if (sceneListener != null) {
-                    sceneListener.changedSize(width, height);
-                }
-                return null;
-            }, getAccessControlContext());
+            if (sceneListener != null) {
+                sceneListener.changedSize(width, height);
+            }
         });
     }
 
@@ -275,7 +269,6 @@ final class EmbeddedScene extends GlassScene implements EmbeddedSceneInterface {
         return super.getClearColor();
     }
 
-    @SuppressWarnings("removal")
     @Override
     public void mouseEvent(final int type, final int button,
                            final boolean primaryBtnDown, final boolean middleBtnDown, final boolean secondaryBtnDown,
@@ -285,10 +278,7 @@ final class EmbeddedScene extends GlassScene implements EmbeddedSceneInterface {
                            final boolean popupTrigger)
     {
         Platform.runLater(() -> {
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                if (sceneListener == null) {
-                    return null;
-                }
+            if (sceneListener != null) {
                 // Click events are generated in Scene, so we don't expect them here
                 assert type != AbstractEvents.MOUSEEVENT_CLICKED;
                 EventType<MouseEvent> eventType = AbstractEvents.mouseIDToFXEventID(type);
@@ -299,12 +289,10 @@ final class EmbeddedScene extends GlassScene implements EmbeddedSceneInterface {
                             primaryBtnDown, middleBtnDown, secondaryBtnDown,
                             backBtnDown, forwardBtnDown
                         );
-                return null;
-            }, getAccessControlContext());
+            }
         });
     }
 
-    @SuppressWarnings("removal")
     @Override
     public void scrollEvent(final int type,
                             final double scrollX, final double scrollY,
@@ -316,129 +304,98 @@ final class EmbeddedScene extends GlassScene implements EmbeddedSceneInterface {
                             final boolean inertia) {
         {
             Platform.runLater(() -> {
-                AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                    if (sceneListener == null) {
-                        return null;
-                    }
+                if (sceneListener != null) {
                     sceneListener.scrollEvent(AbstractEvents.scrollIDToFXEventType(type), scrollX, scrollY, totalScrollX, totalScrollY, xMultiplier, yMultiplier,
                             0, 0, 0, 0, 0, x, y, xAbs, yAbs, shift, ctrl, alt, meta, false, inertia);
-                    return null;
-                }, getAccessControlContext());
+                }
             });
         }
     }
 
-    @SuppressWarnings("removal")
     @Override
     public void inputMethodEvent(final EventType<InputMethodEvent> type,
                                  final ObservableList<InputMethodTextRun> composed, final String committed,
                                  final int caretPosition) {
         Platform.runLater(() -> {
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                if (sceneListener != null) {
-                    sceneListener.inputMethodEvent(type, composed, committed, caretPosition);
-                }
-                return null;
-            });
+            if (sceneListener != null) {
+                sceneListener.inputMethodEvent(type, composed, committed, caretPosition);
+            }
         });
     }
 
-    @SuppressWarnings("removal")
     @Override
     public void menuEvent(final int x, final int y, final int xAbs, final int yAbs, final boolean isKeyboardTrigger) {
         Platform.runLater(() -> {
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                if (sceneListener != null) {
-                    sceneListener.menuEvent(x, y, xAbs, yAbs, isKeyboardTrigger);
-                }
-                return null;
-            }, getAccessControlContext());
+            if (sceneListener != null) {
+                sceneListener.menuEvent(x, y, xAbs, yAbs, isKeyboardTrigger);
+            }
         });
     }
 
-    @SuppressWarnings("removal")
     @Override
     public void keyEvent(final int type, final int key, final char[] ch, final int modifiers) {
         Platform.runLater(() -> {
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                if (sceneListener != null) {
-                    boolean shiftDown = (modifiers & AbstractEvents.MODIFIER_SHIFT) != 0;
-                    boolean controlDown = (modifiers & AbstractEvents.MODIFIER_CONTROL) != 0;
-                    boolean altDown = (modifiers & AbstractEvents.MODIFIER_ALT) != 0;
-                    boolean metaDown = (modifiers & AbstractEvents.MODIFIER_META) != 0;
+            if (sceneListener != null) {
+                boolean shiftDown = (modifiers & AbstractEvents.MODIFIER_SHIFT) != 0;
+                boolean controlDown = (modifiers & AbstractEvents.MODIFIER_CONTROL) != 0;
+                boolean altDown = (modifiers & AbstractEvents.MODIFIER_ALT) != 0;
+                boolean metaDown = (modifiers & AbstractEvents.MODIFIER_META) != 0;
 
-                    String str = new String(ch);
-                    String text = str; // TODO: this must be a text like "HOME", "F1", or "A"
-                    KeyCode code = KeyCodeMap.valueOf(key);
-                    if (code == null) {
-                        code = KeyCode.UNDEFINED;
-                    }
-                    javafx.scene.input.KeyEvent keyEvent = new javafx.scene.input.KeyEvent(
-                            AbstractEvents.keyIDToFXEventType(type),
-                            str, text, code,
-                            shiftDown, controlDown, altDown, metaDown);
-                    sceneListener.keyEvent(keyEvent);
+                String str = new String(ch);
+                String text = str; // TODO: this must be a text like "HOME", "F1", or "A"
+                KeyCode code = KeyCodeMap.valueOf(key);
+                if (code == null) {
+                    code = KeyCode.UNDEFINED;
                 }
-                return null;
-            }, getAccessControlContext());
+                javafx.scene.input.KeyEvent keyEvent = new javafx.scene.input.KeyEvent(
+                        AbstractEvents.keyIDToFXEventType(type),
+                        str, text, code,
+                        shiftDown, controlDown, altDown, metaDown);
+                sceneListener.keyEvent(keyEvent);
+            }
         });
     }
 
-    @SuppressWarnings("removal")
     @Override
     public void zoomEvent(final int type, final double zoomFactor, final double totalZoomFactor,
                           final double x, final double y, final double screenX, final double screenY,
                           boolean shift, boolean ctrl, boolean alt, boolean meta, boolean inertia)
     {
         Platform.runLater(() -> {
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                if (sceneListener == null) {
-                    return null;
-                }
+            if (sceneListener != null) {
                 sceneListener.zoomEvent(AbstractEvents.zoomIDToFXEventType(type),
                         zoomFactor, totalZoomFactor,
                         x, y, screenX, screenY,
                         shift, ctrl, alt, meta, false, inertia);
-                return null;
-            }, getAccessControlContext());
+            }
         });
     }
 
-    @SuppressWarnings("removal")
     @Override
     public void rotateEvent(final int type, final double angle, final double totalAngle,
                           final double x, final double y, final double screenX, final double screenY,
                           boolean shift, boolean ctrl, boolean alt, boolean meta, boolean inertia)
     {
         Platform.runLater(() -> {
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                if (sceneListener == null) {
-                    return null;
-                }
-                sceneListener.rotateEvent(AbstractEvents.rotateIDToFXEventType(type),
-                        angle, totalAngle,
-                        x, y, screenX, screenY,
-                        shift, ctrl, alt, meta, false, inertia);
-                return null;
-            }, getAccessControlContext());
+            if (sceneListener != null) {
+            sceneListener.rotateEvent(AbstractEvents.rotateIDToFXEventType(type),
+                    angle, totalAngle,
+                    x, y, screenX, screenY,
+                    shift, ctrl, alt, meta, false, inertia);
+            }
         });
     }
 
-    @SuppressWarnings("removal")
     @Override
     public void swipeEvent(final int type, final double x, final double y, final double screenX, final double screenY,
                             boolean shift, boolean ctrl, boolean alt, boolean meta)
     {
         Platform.runLater(() -> {
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                if (sceneListener == null) {
-                    return null;
-                }
+            if (sceneListener != null) {
                 sceneListener.swipeEvent(AbstractEvents.swipeIDToFXEventType(type),
                         0, x, y, screenX, screenY,
                         shift, ctrl, alt, meta, false);
-                return null;
-            }, getAccessControlContext());
+            }
         });
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/EmbeddedStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/EmbeddedStage.java
@@ -26,8 +26,6 @@
 package com.sun.javafx.tk.quantum;
 
 import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.List;
 
 import com.sun.javafx.embed.AbstractEvents;
@@ -220,13 +218,8 @@ final class EmbeddedStage extends GlassStage implements EmbeddedStageInterface {
         host.ungrabFocus();
     }
 
-    @SuppressWarnings("removal")
     private void notifyStageListener(final Runnable r) {
-        AccessControlContext acc = getAccessControlContext();
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            r.run();
-            return null;
-        }, acc);
+        r.run();
     }
     private void notifyStageListenerLater(final Runnable r) {
         Platform.runLater(() -> notifyStageListener(r));

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassScene.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassScene.java
@@ -30,7 +30,6 @@ import javafx.scene.input.InputMethodRequests;
 import javafx.stage.StageStyle;
 import java.security.AccessControlContext;
 import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.concurrent.atomic.AtomicBoolean;
 import com.sun.glass.ui.Clipboard;
 import com.sun.glass.ui.ClipboardAssistance;
@@ -247,21 +246,17 @@ abstract class GlassScene implements TKScene {
     @Override
     public TKClipboard createDragboard(boolean isDragSource) {
         ClipboardAssistance assistant = new ClipboardAssistance(Clipboard.DND) {
-            @SuppressWarnings("removal")
             @Override
             public void actionPerformed(final int performedAction) {
                 super.actionPerformed(performedAction);
-                AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                    try {
-                        if (dragSourceListener != null) {
-                            dragSourceListener.dragDropEnd(0, 0, 0, 0,
-                                    QuantumToolkit.clipboardActionToTransferMode(performedAction));
-                        }
-                    } finally {
-                        QuantumClipboard.releaseCurrentDragboard();
+                try {
+                    if (dragSourceListener != null) {
+                        dragSourceListener.dragDropEnd(0, 0, 0, 0,
+                                QuantumToolkit.clipboardActionToTransferMode(performedAction));
                     }
-                    return null;
-                }, getAccessControlContext());
+                } finally {
+                    QuantumClipboard.releaseCurrentDragboard();
+                }
             }
         };
         return QuantumClipboard.getDragboardInstance(assistant, isDragSource);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassSceneDnDEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassSceneDnDEventHandler.java
@@ -33,9 +33,6 @@ import com.sun.glass.ui.ClipboardAssistance;
 import com.sun.glass.ui.View;
 import com.sun.glass.ui.Window;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 class GlassSceneDnDEventHandler {
 
     private final GlassScene scene;
@@ -68,68 +65,55 @@ class GlassSceneDnDEventHandler {
         return 1.0;
     }
 
-    @SuppressWarnings("removal")
     public TransferMode handleDragEnter(final int x, final int y, final int xAbs, final int yAbs,
                                         final TransferMode recommendedTransferMode,
                                         final ClipboardAssistance dropTargetAssistant)
     {
         assert Platform.isFxApplicationThread();
-        return AccessController.doPrivileged((PrivilegedAction<TransferMode>) () -> {
-            if (scene.dropTargetListener != null) {
-                double pScaleX = getPlatformScaleX();
-                double pScaleY = getPlatformScaleY();
-                QuantumClipboard dragboard =
-                        QuantumClipboard.getDragboardInstance(dropTargetAssistant, false);
-                return scene.dropTargetListener.dragEnter(x / pScaleX, y / pScaleY, xAbs / pScaleX, yAbs / pScaleY,
-                        recommendedTransferMode, dragboard);
-            }
-            return null;
-        }, scene.getAccessControlContext());
+        if (scene.dropTargetListener != null) {
+            double pScaleX = getPlatformScaleX();
+            double pScaleY = getPlatformScaleY();
+            QuantumClipboard dragboard =
+                    QuantumClipboard.getDragboardInstance(dropTargetAssistant, false);
+            return scene.dropTargetListener.dragEnter(x / pScaleX, y / pScaleY, xAbs / pScaleX, yAbs / pScaleY,
+                    recommendedTransferMode, dragboard);
+        }
+        return null;
     }
 
-    @SuppressWarnings("removal")
     public void handleDragLeave(final ClipboardAssistance dropTargetAssistant) {
         assert Platform.isFxApplicationThread();
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            if (scene.dropTargetListener != null) {
-                scene.dropTargetListener.dragExit(0, 0, 0, 0);
-            }
-            return null;
-        }, scene.getAccessControlContext());
+        if (scene.dropTargetListener != null) {
+            scene.dropTargetListener.dragExit(0, 0, 0, 0);
+        }
     }
 
-    @SuppressWarnings("removal")
     public TransferMode handleDragDrop(final int x, final int y, final int xAbs, final int yAbs,
                                        final TransferMode recommendedTransferMode,
                                        final ClipboardAssistance dropTargetAssistant)
     {
         assert Platform.isFxApplicationThread();
-        return AccessController.doPrivileged((PrivilegedAction<TransferMode>) () -> {
-            if (scene.dropTargetListener != null) {
-                double pScaleX = getPlatformScaleX();
-                double pScaleY = getPlatformScaleY();
-                return scene.dropTargetListener.drop(x / pScaleX, y / pScaleY, xAbs / pScaleX, yAbs / pScaleY,
-                        recommendedTransferMode);
-            }
-            return null;
-        }, scene.getAccessControlContext());
+        if (scene.dropTargetListener != null) {
+            double pScaleX = getPlatformScaleX();
+            double pScaleY = getPlatformScaleY();
+            return scene.dropTargetListener.drop(x / pScaleX, y / pScaleY, xAbs / pScaleX, yAbs / pScaleY,
+                    recommendedTransferMode);
+        }
+        return null;
     }
 
-    @SuppressWarnings("removal")
     public TransferMode handleDragOver(final int x, final int y, final int xAbs, final int yAbs,
                                        final TransferMode recommendedTransferMode,
                                        final ClipboardAssistance dropTargetAssistant)
     {
         assert Platform.isFxApplicationThread();
-        return AccessController.doPrivileged((PrivilegedAction<TransferMode>) () -> {
-            if (scene.dropTargetListener != null) {
-                double pScaleX = getPlatformScaleX();
-                double pScaleY = getPlatformScaleY();
-                return scene.dropTargetListener.dragOver(x / pScaleX, y / pScaleY, xAbs / pScaleX, yAbs / pScaleY,
-                        recommendedTransferMode);
-            }
-            return null;
-        }, scene.getAccessControlContext());
+        if (scene.dropTargetListener != null) {
+            double pScaleX = getPlatformScaleX();
+            double pScaleY = getPlatformScaleY();
+            return scene.dropTargetListener.dragOver(x / pScaleX, y / pScaleY, xAbs / pScaleX, yAbs / pScaleY,
+                    recommendedTransferMode);
+        }
+        return null;
     }
 
     // Drag source handlers
@@ -138,42 +122,34 @@ class GlassSceneDnDEventHandler {
     // detected. This mechanism is currently not used in FX, as we have
     // a custom gesture recognizer in Scene, and DnD is started with
     // Toolkit.startDrag().
-    @SuppressWarnings("removal")
     public void handleDragStart(final int button, final int x, final int y, final int xAbs, final int yAbs,
                                 final ClipboardAssistance dragSourceAssistant)
     {
         assert Platform.isFxApplicationThread();
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            if (scene.dragGestureListener != null) {
-                double pScaleX = getPlatformScaleX();
-                double pScaleY = getPlatformScaleY();
-                QuantumClipboard dragboard =
-                        QuantumClipboard.getDragboardInstance(dragSourceAssistant, true);
-                scene.dragGestureListener.dragGestureRecognized(
-                        x / pScaleX, y / pScaleY, xAbs / pScaleX, yAbs / pScaleY, button, dragboard);
-            }
-            return null;
-        }, scene.getAccessControlContext());
+        if (scene.dragGestureListener != null) {
+            double pScaleX = getPlatformScaleX();
+            double pScaleY = getPlatformScaleY();
+            QuantumClipboard dragboard =
+                    QuantumClipboard.getDragboardInstance(dragSourceAssistant, true);
+            scene.dragGestureListener.dragGestureRecognized(
+                    x / pScaleX, y / pScaleY, xAbs / pScaleX, yAbs / pScaleY, button, dragboard);
+        }
     }
 
     // This is a callback from the native platform, when the drag was started
     // from handleDragStart() above, or when FX as a drag source is embedded
     // to Swing/SWT.
-    @SuppressWarnings("removal")
     public void handleDragEnd(final TransferMode performedTransferMode,
                               final ClipboardAssistance dragSourceAssistant)
     {
         assert Platform.isFxApplicationThread();
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            try {
-                if (scene.dragSourceListener != null) {
-                    scene.dragSourceListener.dragDropEnd(0, 0, 0, 0, performedTransferMode);
-                }
-            } finally {
-                QuantumClipboard.releaseCurrentDragboard();
+        try {
+            if (scene.dragSourceListener != null) {
+                scene.dragSourceListener.dragDropEnd(0, 0, 0, 0, performedTransferMode);
             }
-            return null;
-        }, scene.getAccessControlContext());
+        } finally {
+            QuantumClipboard.releaseCurrentDragboard();
+        }
     }
 
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassStage.java
@@ -107,11 +107,12 @@ abstract class GlassStage implements TKStage {
     static AccessControlContext doIntersectionPrivilege(PrivilegedAction<AccessControlContext> action,
                                                        AccessControlContext stack,
                                                        AccessControlContext context) {
-        return AccessController.doPrivileged((PrivilegedAction<AccessControlContext>) () -> {
-            return AccessController.doPrivilegedWithCombiner((PrivilegedAction<AccessControlContext>) () -> {
-                return AccessController.getContext();
-            }, stack);
-        },  context);
+        // As part of the security manager removal, this entire method will be eliminated.
+        // This method used to compute the intersection of two access control contexts using
+        // a custom doPrivilegedWithCombiner method. This was only used in other calls to
+        // doPrivilieged, so there is no harm in skipping the intersection and just
+        // returning the context.
+        return context;
     }
 
     @SuppressWarnings("removal")
@@ -189,7 +190,6 @@ abstract class GlassStage implements TKStage {
     }
 
     // Cmd+Q action
-    @SuppressWarnings("removal")
     static void requestClosingAllWindows() {
         GlassStage fsWindow = activeFSWindow.get();
         if (fsWindow != null) {
@@ -200,10 +200,7 @@ abstract class GlassStage implements TKStage {
             // In case of child windows some of them could already be closed
             // so check if list still contains an object
             if (windows.contains(window) && window.isVisible() && window.stageListener != null) {
-                AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                    window.stageListener.closing();
-                    return null;
-                }, window.getAccessControlContext());
+                window.stageListener.closing();
             }
         }
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
@@ -60,8 +60,7 @@ import javafx.scene.input.TouchPoint;
 import javafx.scene.input.TransferMode;
 import javafx.scene.input.ZoomEvent;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
+import java.util.function.Supplier;
 
 class GlassViewEventHandler extends View.EventHandler {
 
@@ -69,13 +68,9 @@ class GlassViewEventHandler extends View.EventHandler {
     static boolean rotateGestureEnabled;
     static boolean scrollGestureEnabled;
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            zoomGestureEnabled = Boolean.valueOf(System.getProperty("com.sun.javafx.gestures.zoom", "false"));
-            rotateGestureEnabled = Boolean.valueOf(System.getProperty("com.sun.javafx.gestures.rotate", "false"));
-            scrollGestureEnabled = Boolean.valueOf(System.getProperty("com.sun.javafx.gestures.scroll", "false"));
-            return null;
-        });
+        zoomGestureEnabled = Boolean.valueOf(System.getProperty("com.sun.javafx.gestures.zoom", "false"));
+        rotateGestureEnabled = Boolean.valueOf(System.getProperty("com.sun.javafx.gestures.rotate", "false"));
+        scrollGestureEnabled = Boolean.valueOf(System.getProperty("com.sun.javafx.gestures.scroll", "false"));
     }
 
     private ViewScene scene;
@@ -147,7 +142,7 @@ class GlassViewEventHandler extends View.EventHandler {
     }
 
     private final KeyEventNotification keyNotification = new KeyEventNotification();
-    private class KeyEventNotification implements PrivilegedAction<Boolean> {
+    private class KeyEventNotification implements Supplier<Boolean> {
         View view;
         long time;
         int type;
@@ -158,7 +153,7 @@ class GlassViewEventHandler extends View.EventHandler {
         private KeyCode lastKeyCode;
 
         @Override
-        public Boolean run() {
+        public Boolean get() {
             if (PULSE_LOGGING_ENABLED) {
                 PulseLogger.newInput(keyEventType(type).toString());
             }
@@ -236,7 +231,6 @@ class GlassViewEventHandler extends View.EventHandler {
         }
     }
 
-    @SuppressWarnings("removal")
     @Override
     public boolean handleKeyEvent(View view, long time, int type, int key,
                                   char[] chars, int modifiers)
@@ -248,9 +242,7 @@ class GlassViewEventHandler extends View.EventHandler {
         keyNotification.chars = chars;
         keyNotification.modifiers = modifiers;
 
-        boolean consumed = QuantumToolkit.runWithoutRenderLock(() -> {
-            return AccessController.doPrivileged(keyNotification, scene.getAccessControlContext());
-        });
+        boolean consumed = QuantumToolkit.runWithoutRenderLock(keyNotification);
         return consumed;
     }
 
@@ -301,7 +293,7 @@ class GlassViewEventHandler extends View.EventHandler {
     private int mouseButtonPressedMask = 0;
 
     private final MouseEventNotification mouseNotification = new MouseEventNotification();
-    private class MouseEventNotification implements PrivilegedAction<Void> {
+    private class MouseEventNotification implements Supplier<Void> {
         View view;
         long time;
         int type;
@@ -312,7 +304,7 @@ class GlassViewEventHandler extends View.EventHandler {
         boolean isSynthesized;
 
         @Override
-        public Void run() {
+        public Void get() {
             if (PULSE_LOGGING_ENABLED) {
                 PulseLogger.newInput(mouseEventType(type).toString());
             }
@@ -431,7 +423,6 @@ class GlassViewEventHandler extends View.EventHandler {
         }
     }
 
-    @SuppressWarnings("removal")
     @Override
     public void handleMouseEvent(View view, long time, int type, int button,
                                  int x, int y, int xAbs, int yAbs,
@@ -449,12 +440,9 @@ class GlassViewEventHandler extends View.EventHandler {
         mouseNotification.isPopupTrigger = isPopupTrigger;
         mouseNotification.isSynthesized = isSynthesized;
 
-        QuantumToolkit.runWithoutRenderLock(() -> {
-            return AccessController.doPrivileged(mouseNotification, scene.getAccessControlContext());
-        });
+        QuantumToolkit.runWithoutRenderLock(mouseNotification);
     }
 
-    @SuppressWarnings("removal")
     @Override public void handleMenuEvent(final View view,
                                           final int x, final int y, final int xAbs, final int yAbs,
                                           final boolean isKeyboardTrigger)
@@ -468,33 +456,31 @@ class GlassViewEventHandler extends View.EventHandler {
                 stage.setInAllowedEventHandler(true);
             }
             QuantumToolkit.runWithoutRenderLock(() -> {
-                return AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                    if (scene.sceneListener != null) {
-                        double pScaleX, pScaleY, spx, spy, sx, sy;
-                        final Window w = view.getWindow();
-                        if (w != null) {
-                            pScaleX = w.getPlatformScaleX();
-                            pScaleY = w.getPlatformScaleY();
-                            Screen scr = w.getScreen();
-                            if (scr != null) {
-                                spx = scr.getPlatformX();
-                                spy = scr.getPlatformY();
-                                sx = scr.getX();
-                                sy = scr.getY();
-                            } else {
-                                spx = spy = sx = sy = 0.0;
-                            }
+                if (scene.sceneListener != null) {
+                    double pScaleX, pScaleY, spx, spy, sx, sy;
+                    final Window w = view.getWindow();
+                    if (w != null) {
+                        pScaleX = w.getPlatformScaleX();
+                        pScaleY = w.getPlatformScaleY();
+                        Screen scr = w.getScreen();
+                        if (scr != null) {
+                            spx = scr.getPlatformX();
+                            spy = scr.getPlatformY();
+                            sx = scr.getX();
+                            sy = scr.getY();
                         } else {
-                            pScaleX = pScaleY = 1.0;
                             spx = spy = sx = sy = 0.0;
                         }
-                        scene.sceneListener.menuEvent(x / pScaleX, y / pScaleY,
-                                                      sx + (xAbs - spx) / pScaleX,
-                                                      sy + (yAbs - spy) / pScaleY,
-                                                      isKeyboardTrigger);
+                    } else {
+                        pScaleX = pScaleY = 1.0;
+                        spx = spy = sx = sy = 0.0;
                     }
-                    return null;
-                }, scene.getAccessControlContext());
+                    scene.sceneListener.menuEvent(x / pScaleX, y / pScaleY,
+                                                  sx + (xAbs - spx) / pScaleX,
+                                                  sy + (yAbs - spy) / pScaleY,
+                                                  isKeyboardTrigger);
+                }
+                return null;
             });
         } finally {
             if (stage != null) {
@@ -506,7 +492,6 @@ class GlassViewEventHandler extends View.EventHandler {
         }
     }
 
-    @SuppressWarnings("removal")
     @Override public void handleScrollEvent(final View view, final long time,
                                             final int x, final int y, final int xAbs, final int yAbs,
                                             final double deltaX, final double deltaY, final int modifiers,
@@ -523,43 +508,41 @@ class GlassViewEventHandler extends View.EventHandler {
                 stage.setInAllowedEventHandler(false);
             }
             QuantumToolkit.runWithoutRenderLock(() -> {
-                return AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                    if (scene.sceneListener != null) {
-                        final Window w = view.getWindow();
-                        double pScaleX, pScaleY, spx, spy, sx, sy;
-                        if (w != null) {
-                            pScaleX = w.getPlatformScaleX();
-                            pScaleY = w.getPlatformScaleY();
-                            Screen scr = w.getScreen();
-                            if (scr != null) {
-                                spx = scr.getPlatformX();
-                                spy = scr.getPlatformY();
-                                sx = scr.getX();
-                                sy = scr.getY();
-                            } else {
-                                spx = spy = sx = sy = 0.0;
-                            }
+                if (scene.sceneListener != null) {
+                    final Window w = view.getWindow();
+                    double pScaleX, pScaleY, spx, spy, sx, sy;
+                    if (w != null) {
+                        pScaleX = w.getPlatformScaleX();
+                        pScaleY = w.getPlatformScaleY();
+                        Screen scr = w.getScreen();
+                        if (scr != null) {
+                            spx = scr.getPlatformX();
+                            spy = scr.getPlatformY();
+                            sx = scr.getX();
+                            sy = scr.getY();
                         } else {
-                            pScaleX = pScaleY = 1.0;
                             spx = spy = sx = sy = 0.0;
                         }
-                        scene.sceneListener.scrollEvent(ScrollEvent.SCROLL,
-                            deltaX / pScaleX, deltaY / pScaleY, 0, 0,
-                            xMultiplier, yMultiplier,
-                            0, // touchCount
-                            chars, lines, defaultChars, defaultLines,
-                            x / pScaleX, y / pScaleY,
-                            sx + (xAbs - spx) / pScaleX,
-                            sy + (yAbs - spy) / pScaleY,
-                            (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
-                            (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
-                            (modifiers & KeyEvent.MODIFIER_ALT) != 0,
-                            (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
-                            false, // this is always indirect
-                            false); // this has no inertia
+                    } else {
+                        pScaleX = pScaleY = 1.0;
+                        spx = spy = sx = sy = 0.0;
                     }
-                    return null;
-                }, scene.getAccessControlContext());
+                    scene.sceneListener.scrollEvent(ScrollEvent.SCROLL,
+                        deltaX / pScaleX, deltaY / pScaleY, 0, 0,
+                        xMultiplier, yMultiplier,
+                        0, // touchCount
+                        chars, lines, defaultChars, defaultLines,
+                        x / pScaleX, y / pScaleY,
+                        sx + (xAbs - spx) / pScaleX,
+                        sy + (yAbs - spy) / pScaleY,
+                        (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
+                        (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
+                        (modifiers & KeyEvent.MODIFIER_ALT) != 0,
+                        (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
+                        false, // this is always indirect
+                        false); // this has no inertia
+                }
+                return null;
             });
         } finally {
             if (stage != null) {
@@ -631,7 +614,6 @@ class GlassViewEventHandler extends View.EventHandler {
         return composed;
     }
 
-    @SuppressWarnings("removal")
     @Override public void handleInputMethodEvent(final long time, final String text,
                                                  final int[] clauseBoundary,
                                                  final int[] attrBoundary, final byte[] attrValue,
@@ -646,18 +628,16 @@ class GlassViewEventHandler extends View.EventHandler {
                 stage.setInAllowedEventHandler(true);
             }
             QuantumToolkit.runWithoutRenderLock(() -> {
-                return AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                    if (scene.sceneListener != null) {
-                        String t = text != null ? text : "";
-                        EventType<InputMethodEvent> eventType =
-                                InputMethodEvent.INPUT_METHOD_TEXT_CHANGED;
-                        ObservableList<InputMethodTextRun> composed = inputMethodEventComposed(
-                                t, commitCount, clauseBoundary, attrBoundary, attrValue);
-                        String committed = t.substring(0, commitCount);
-                        scene.sceneListener.inputMethodEvent(eventType, composed, committed, cursorPos);
-                    }
-                    return null;
-                }, scene.getAccessControlContext());
+                if (scene.sceneListener != null) {
+                    String t = text != null ? text : "";
+                    EventType<InputMethodEvent> eventType =
+                            InputMethodEvent.INPUT_METHOD_TEXT_CHANGED;
+                    ObservableList<InputMethodTextRun> composed = inputMethodEventComposed(
+                            t, commitCount, clauseBoundary, attrBoundary, attrValue);
+                    String committed = t.substring(0, commitCount);
+                    scene.sceneListener.inputMethodEvent(eventType, composed, committed, cursorPos);
+                }
+                return null;
             });
         } finally {
             if (stage != null) {
@@ -862,13 +842,13 @@ class GlassViewEventHandler extends View.EventHandler {
     // TODO - dragSourceListener.dropActionChanged
 
     private final ViewEventNotification viewNotification = new ViewEventNotification();
-    private class ViewEventNotification implements PrivilegedAction<Void> {
+    private class ViewEventNotification implements Supplier<Void> {
         View view;
         long time;
         int type;
 
         @Override
-        public Void run() {
+        public Void get() {
             if (scene.sceneListener == null) {
                 return null;
             }
@@ -934,7 +914,6 @@ class GlassViewEventHandler extends View.EventHandler {
         }
     }
 
-    @SuppressWarnings("removal")
     @Override public void handleViewEvent(View view, long time, final int type) {
         if (PULSE_LOGGING_ENABLED) {
             PulseLogger.newInput("VIEW_EVENT: "+ViewEvent.getTypeString(type));
@@ -943,9 +922,7 @@ class GlassViewEventHandler extends View.EventHandler {
         viewNotification.time = time;
         viewNotification.type = type;
         try {
-            QuantumToolkit.runWithoutRenderLock(() -> {
-                return AccessController.doPrivileged(viewNotification, scene.getAccessControlContext());
-            });
+            QuantumToolkit.runWithoutRenderLock(viewNotification);
         }
         finally {
             if (PULSE_LOGGING_ENABLED) {
@@ -954,7 +931,6 @@ class GlassViewEventHandler extends View.EventHandler {
         }
     }
 
-    @SuppressWarnings("removal")
     @Override public void handleScrollGestureEvent(
             View view, final long time, final int type,
             final int modifiers, final boolean isDirect, final boolean isInertia, final int touchCount,
@@ -970,57 +946,55 @@ class GlassViewEventHandler extends View.EventHandler {
                 stage.setInAllowedEventHandler(false);
             }
             QuantumToolkit.runWithoutRenderLock(() -> {
-                return AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                    if (scene.sceneListener != null) {
-                        EventType<ScrollEvent> eventType;
-                        switch(type) {
-                            case GestureEvent.GESTURE_STARTED:
-                                eventType = ScrollEvent.SCROLL_STARTED;
-                                break;
-                            case GestureEvent.GESTURE_PERFORMED:
-                                eventType = ScrollEvent.SCROLL;
-                                break;
-                            case GestureEvent.GESTURE_FINISHED:
-                                eventType = ScrollEvent.SCROLL_FINISHED;
-                                break;
-                            default:
-                                throw new RuntimeException("Unknown scroll event type: " + type);
-                        }
-                        final Window w = view.getWindow();
-                        double pScaleX, pScaleY, spx, spy, sx, sy;
-                        if (w != null) {
-                            pScaleX = w.getPlatformScaleX();
-                            pScaleY = w.getPlatformScaleY();
-                            Screen scr = w.getScreen();
-                            if (scr != null) {
-                                spx = scr.getPlatformX();
-                                spy = scr.getPlatformY();
-                                sx = scr.getX();
-                                sy = scr.getY();
-                            } else {
-                                spx = spy = sx = sy = 0.0;
-                            }
+                if (scene.sceneListener != null) {
+                    EventType<ScrollEvent> eventType;
+                    switch(type) {
+                        case GestureEvent.GESTURE_STARTED:
+                            eventType = ScrollEvent.SCROLL_STARTED;
+                            break;
+                        case GestureEvent.GESTURE_PERFORMED:
+                            eventType = ScrollEvent.SCROLL;
+                            break;
+                        case GestureEvent.GESTURE_FINISHED:
+                            eventType = ScrollEvent.SCROLL_FINISHED;
+                            break;
+                        default:
+                            throw new RuntimeException("Unknown scroll event type: " + type);
+                    }
+                    final Window w = view.getWindow();
+                    double pScaleX, pScaleY, spx, spy, sx, sy;
+                    if (w != null) {
+                        pScaleX = w.getPlatformScaleX();
+                        pScaleY = w.getPlatformScaleY();
+                        Screen scr = w.getScreen();
+                        if (scr != null) {
+                            spx = scr.getPlatformX();
+                            spy = scr.getPlatformY();
+                            sx = scr.getX();
+                            sy = scr.getY();
                         } else {
-                            pScaleX = pScaleY = 1.0;
                             spx = spy = sx = sy = 0.0;
                         }
-                        scene.sceneListener.scrollEvent(eventType,
-                                dx / pScaleX, dy / pScaleY, totaldx / pScaleX, totaldy / pScaleY,
-                                multiplierX, multiplierY,
-                                touchCount,
-                                0, 0, 0, 0,
-                                x == View.GESTURE_NO_VALUE ? Double.NaN : x / pScaleX,
-                                y == View.GESTURE_NO_VALUE ? Double.NaN : y / pScaleY,
-                                xAbs == View.GESTURE_NO_VALUE ? Double.NaN : sx + (xAbs - spx) / pScaleX,
-                                yAbs == View.GESTURE_NO_VALUE ? Double.NaN : sy + (yAbs - spy) / pScaleY,
-                                (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
-                                (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
-                                (modifiers & KeyEvent.MODIFIER_ALT) != 0,
-                                (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
-                                isDirect, isInertia);
+                    } else {
+                        pScaleX = pScaleY = 1.0;
+                        spx = spy = sx = sy = 0.0;
                     }
-                    return null;
-                }, scene.getAccessControlContext());
+                    scene.sceneListener.scrollEvent(eventType,
+                            dx / pScaleX, dy / pScaleY, totaldx / pScaleX, totaldy / pScaleY,
+                            multiplierX, multiplierY,
+                            touchCount,
+                            0, 0, 0, 0,
+                            x == View.GESTURE_NO_VALUE ? Double.NaN : x / pScaleX,
+                            y == View.GESTURE_NO_VALUE ? Double.NaN : y / pScaleY,
+                            xAbs == View.GESTURE_NO_VALUE ? Double.NaN : sx + (xAbs - spx) / pScaleX,
+                            yAbs == View.GESTURE_NO_VALUE ? Double.NaN : sy + (yAbs - spy) / pScaleY,
+                            (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
+                            (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
+                            (modifiers & KeyEvent.MODIFIER_ALT) != 0,
+                            (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
+                            isDirect, isInertia);
+                }
+                return null;
             });
         } finally {
             if (stage != null) {
@@ -1032,7 +1006,6 @@ class GlassViewEventHandler extends View.EventHandler {
         }
     }
 
-    @SuppressWarnings("removal")
     @Override public void handleZoomGestureEvent(
             View view, final long time, final int type,
             final int modifiers, final boolean isDirect, final boolean isInertia,
@@ -1050,54 +1023,52 @@ class GlassViewEventHandler extends View.EventHandler {
                 stage.setInAllowedEventHandler(false);
             }
             QuantumToolkit.runWithoutRenderLock(() -> {
-                return AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                    if (scene.sceneListener != null) {
-                        EventType<ZoomEvent> eventType;
-                        switch (type) {
-                            case GestureEvent.GESTURE_STARTED:
-                                eventType = ZoomEvent.ZOOM_STARTED;
-                                break;
-                            case GestureEvent.GESTURE_PERFORMED:
-                                eventType = ZoomEvent.ZOOM;
-                                break;
-                            case GestureEvent.GESTURE_FINISHED:
-                                eventType = ZoomEvent.ZOOM_FINISHED;
-                                break;
-                            default:
-                                throw new RuntimeException("Unknown scroll event type: " + type);
-                        }
-                        final Window w = view.getWindow();
-                        double pScaleX, pScaleY, spx, spy, sx, sy;
-                        if (w != null) {
-                            pScaleX = w.getPlatformScaleX();
-                            pScaleY = w.getPlatformScaleY();
-                            Screen scr = w.getScreen();
-                            if (scr != null) {
-                                spx = scr.getPlatformX();
-                                spy = scr.getPlatformY();
-                                sx = scr.getX();
-                                sy = scr.getY();
-                            } else {
-                                spx = spy = sx = sy = 0.0;
-                            }
+                if (scene.sceneListener != null) {
+                    EventType<ZoomEvent> eventType;
+                    switch (type) {
+                        case GestureEvent.GESTURE_STARTED:
+                            eventType = ZoomEvent.ZOOM_STARTED;
+                            break;
+                        case GestureEvent.GESTURE_PERFORMED:
+                            eventType = ZoomEvent.ZOOM;
+                            break;
+                        case GestureEvent.GESTURE_FINISHED:
+                            eventType = ZoomEvent.ZOOM_FINISHED;
+                            break;
+                        default:
+                            throw new RuntimeException("Unknown scroll event type: " + type);
+                    }
+                    final Window w = view.getWindow();
+                    double pScaleX, pScaleY, spx, spy, sx, sy;
+                    if (w != null) {
+                        pScaleX = w.getPlatformScaleX();
+                        pScaleY = w.getPlatformScaleY();
+                        Screen scr = w.getScreen();
+                        if (scr != null) {
+                            spx = scr.getPlatformX();
+                            spy = scr.getPlatformY();
+                            sx = scr.getX();
+                            sy = scr.getY();
                         } else {
-                            pScaleX = pScaleY = 1.0;
                             spx = spy = sx = sy = 0.0;
                         }
-                        // REMIND: Scale the [total]scale params too?
-                        scene.sceneListener.zoomEvent(eventType, scale, totalscale,
-                                originx == View.GESTURE_NO_VALUE ? Double.NaN : originx / pScaleX,
-                                originy == View.GESTURE_NO_VALUE ? Double.NaN : originy / pScaleY,
-                                originxAbs == View.GESTURE_NO_VALUE ? Double.NaN : sx + (originxAbs - spx) / pScaleX,
-                                originyAbs == View.GESTURE_NO_VALUE ? Double.NaN : sy + (originyAbs - spy) / pScaleY,
-                                (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
-                                (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
-                                (modifiers & KeyEvent.MODIFIER_ALT) != 0,
-                                (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
-                                isDirect, isInertia);
+                    } else {
+                        pScaleX = pScaleY = 1.0;
+                        spx = spy = sx = sy = 0.0;
                     }
-                    return null;
-                }, scene.getAccessControlContext());
+                    // REMIND: Scale the [total]scale params too?
+                    scene.sceneListener.zoomEvent(eventType, scale, totalscale,
+                            originx == View.GESTURE_NO_VALUE ? Double.NaN : originx / pScaleX,
+                            originy == View.GESTURE_NO_VALUE ? Double.NaN : originy / pScaleY,
+                            originxAbs == View.GESTURE_NO_VALUE ? Double.NaN : sx + (originxAbs - spx) / pScaleX,
+                            originyAbs == View.GESTURE_NO_VALUE ? Double.NaN : sy + (originyAbs - spy) / pScaleY,
+                            (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
+                            (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
+                            (modifiers & KeyEvent.MODIFIER_ALT) != 0,
+                            (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
+                            isDirect, isInertia);
+                }
+                return null;
             });
         } finally {
             if (stage != null) {
@@ -1109,7 +1080,6 @@ class GlassViewEventHandler extends View.EventHandler {
         }
     }
 
-    @SuppressWarnings("removal")
     @Override public void handleRotateGestureEvent(
             View view, final long time, final int type,
             final int modifiers, final boolean isDirect, final boolean isInertia,
@@ -1126,53 +1096,51 @@ class GlassViewEventHandler extends View.EventHandler {
                 stage.setInAllowedEventHandler(false);
             }
             QuantumToolkit.runWithoutRenderLock(() -> {
-                return AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                    if (scene.sceneListener != null) {
-                        EventType<RotateEvent> eventType;
-                        switch (type) {
-                            case GestureEvent.GESTURE_STARTED:
-                                eventType = RotateEvent.ROTATION_STARTED;
-                                break;
-                            case GestureEvent.GESTURE_PERFORMED:
-                                eventType = RotateEvent.ROTATE;
-                                break;
-                            case GestureEvent.GESTURE_FINISHED:
-                                eventType = RotateEvent.ROTATION_FINISHED;
-                                break;
-                            default:
-                                throw new RuntimeException("Unknown scroll event type: " + type);
-                        }
-                        final Window w = view.getWindow();
-                        double pScaleX, pScaleY, spx, spy, sx, sy;
-                        if (w != null) {
-                            pScaleX = w.getPlatformScaleX();
-                            pScaleY = w.getPlatformScaleY();
-                            Screen scr = w.getScreen();
-                            if (scr != null) {
-                                spx = scr.getPlatformX();
-                                spy = scr.getPlatformY();
-                                sx = scr.getX();
-                                sy = scr.getY();
-                            } else {
-                                spx = spy = sx = sy = 0.0;
-                            }
+                if (scene.sceneListener != null) {
+                    EventType<RotateEvent> eventType;
+                    switch (type) {
+                        case GestureEvent.GESTURE_STARTED:
+                            eventType = RotateEvent.ROTATION_STARTED;
+                            break;
+                        case GestureEvent.GESTURE_PERFORMED:
+                            eventType = RotateEvent.ROTATE;
+                            break;
+                        case GestureEvent.GESTURE_FINISHED:
+                            eventType = RotateEvent.ROTATION_FINISHED;
+                            break;
+                        default:
+                            throw new RuntimeException("Unknown scroll event type: " + type);
+                    }
+                    final Window w = view.getWindow();
+                    double pScaleX, pScaleY, spx, spy, sx, sy;
+                    if (w != null) {
+                        pScaleX = w.getPlatformScaleX();
+                        pScaleY = w.getPlatformScaleY();
+                        Screen scr = w.getScreen();
+                        if (scr != null) {
+                            spx = scr.getPlatformX();
+                            spy = scr.getPlatformY();
+                            sx = scr.getX();
+                            sy = scr.getY();
                         } else {
-                            pScaleX = pScaleY = 1.0;
                             spx = spy = sx = sy = 0.0;
                         }
-                        scene.sceneListener.rotateEvent(eventType, dangle, totalangle,
-                                originx == View.GESTURE_NO_VALUE ? Double.NaN : originx / pScaleX,
-                                originy == View.GESTURE_NO_VALUE ? Double.NaN : originy / pScaleY,
-                                originxAbs == View.GESTURE_NO_VALUE ? Double.NaN : sx + (originxAbs - spx) / pScaleX,
-                                originyAbs == View.GESTURE_NO_VALUE ? Double.NaN : sy + (originyAbs - spy) / pScaleY,
-                                (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
-                                (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
-                                (modifiers & KeyEvent.MODIFIER_ALT) != 0,
-                                (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
-                                isDirect, isInertia);
+                    } else {
+                        pScaleX = pScaleY = 1.0;
+                        spx = spy = sx = sy = 0.0;
                     }
-                    return null;
-                }, scene.getAccessControlContext());
+                    scene.sceneListener.rotateEvent(eventType, dangle, totalangle,
+                            originx == View.GESTURE_NO_VALUE ? Double.NaN : originx / pScaleX,
+                            originy == View.GESTURE_NO_VALUE ? Double.NaN : originy / pScaleY,
+                            originxAbs == View.GESTURE_NO_VALUE ? Double.NaN : sx + (originxAbs - spx) / pScaleX,
+                            originyAbs == View.GESTURE_NO_VALUE ? Double.NaN : sy + (originyAbs - spy) / pScaleY,
+                            (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
+                            (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
+                            (modifiers & KeyEvent.MODIFIER_ALT) != 0,
+                            (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
+                            isDirect, isInertia);
+                }
+                return null;
             });
         } finally {
             if (stage != null) {
@@ -1184,7 +1152,6 @@ class GlassViewEventHandler extends View.EventHandler {
         }
     }
 
-    @SuppressWarnings("removal")
     @Override public void handleSwipeGestureEvent(
             View view, final long time, int type,
             final int modifiers, final boolean isDirect,
@@ -1200,56 +1167,54 @@ class GlassViewEventHandler extends View.EventHandler {
                 stage.setInAllowedEventHandler(false);
             }
             QuantumToolkit.runWithoutRenderLock(() -> {
-                return AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                    if (scene.sceneListener != null) {
-                        EventType<SwipeEvent> eventType;
-                        switch (dir) {
-                            case SwipeGesture.DIR_UP:
-                                eventType = SwipeEvent.SWIPE_UP;
-                                break;
-                            case SwipeGesture.DIR_DOWN:
-                                eventType = SwipeEvent.SWIPE_DOWN;
-                                break;
-                            case SwipeGesture.DIR_LEFT:
-                                eventType = SwipeEvent.SWIPE_LEFT;
-                                break;
-                            case SwipeGesture.DIR_RIGHT:
-                                eventType = SwipeEvent.SWIPE_RIGHT;
-                                break;
-                            default:
-                                throw new RuntimeException("Unknown swipe event direction: " + dir);
-                        }
-                        final Window w = view.getWindow();
-                        double pScaleX, pScaleY, spx, spy, sx, sy;
-                        if (w != null) {
-                            pScaleX = w.getPlatformScaleX();
-                            pScaleY = w.getPlatformScaleY();
-                            Screen scr = w.getScreen();
-                            if (scr != null) {
-                                spx = scr.getPlatformX();
-                                spy = scr.getPlatformY();
-                                sx = scr.getX();
-                                sy = scr.getY();
-                            } else {
-                                spx = spy = sx = sy = 0.0;
-                            }
+                if (scene.sceneListener != null) {
+                    EventType<SwipeEvent> eventType;
+                    switch (dir) {
+                        case SwipeGesture.DIR_UP:
+                            eventType = SwipeEvent.SWIPE_UP;
+                            break;
+                        case SwipeGesture.DIR_DOWN:
+                            eventType = SwipeEvent.SWIPE_DOWN;
+                            break;
+                        case SwipeGesture.DIR_LEFT:
+                            eventType = SwipeEvent.SWIPE_LEFT;
+                            break;
+                        case SwipeGesture.DIR_RIGHT:
+                            eventType = SwipeEvent.SWIPE_RIGHT;
+                            break;
+                        default:
+                            throw new RuntimeException("Unknown swipe event direction: " + dir);
+                    }
+                    final Window w = view.getWindow();
+                    double pScaleX, pScaleY, spx, spy, sx, sy;
+                    if (w != null) {
+                        pScaleX = w.getPlatformScaleX();
+                        pScaleY = w.getPlatformScaleY();
+                        Screen scr = w.getScreen();
+                        if (scr != null) {
+                            spx = scr.getPlatformX();
+                            spy = scr.getPlatformY();
+                            sx = scr.getX();
+                            sy = scr.getY();
                         } else {
-                            pScaleX = pScaleY = 1.0;
                             spx = spy = sx = sy = 0.0;
                         }
-                        scene.sceneListener.swipeEvent(eventType, touchCount,
-                                x == View.GESTURE_NO_VALUE ? Double.NaN : x / pScaleX,
-                                y == View.GESTURE_NO_VALUE ? Double.NaN : y / pScaleY,
-                                xAbs == View.GESTURE_NO_VALUE ? Double.NaN : sx + (xAbs - spx) / pScaleX,
-                                yAbs == View.GESTURE_NO_VALUE ? Double.NaN : sy + (yAbs - spy) / pScaleY,
-                                (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
-                                (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
-                                (modifiers & KeyEvent.MODIFIER_ALT) != 0,
-                                (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
-                                isDirect);
+                    } else {
+                        pScaleX = pScaleY = 1.0;
+                        spx = spy = sx = sy = 0.0;
                     }
-                    return null;
-                }, scene.getAccessControlContext());
+                    scene.sceneListener.swipeEvent(eventType, touchCount,
+                            x == View.GESTURE_NO_VALUE ? Double.NaN : x / pScaleX,
+                            y == View.GESTURE_NO_VALUE ? Double.NaN : y / pScaleY,
+                            xAbs == View.GESTURE_NO_VALUE ? Double.NaN : sx + (xAbs - spx) / pScaleX,
+                            yAbs == View.GESTURE_NO_VALUE ? Double.NaN : sy + (yAbs - spy) / pScaleY,
+                            (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
+                            (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
+                            (modifiers & KeyEvent.MODIFIER_ALT) != 0,
+                            (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
+                            isDirect);
+                }
+                return null;
             });
         } finally {
             if (stage != null) {
@@ -1261,7 +1226,6 @@ class GlassViewEventHandler extends View.EventHandler {
         }
     }
 
-    @SuppressWarnings("removal")
     @Override public void handleBeginTouchEvent(
             View view, final long time, final int modifiers,
             final boolean isDirect, final int touchEventCount)
@@ -1275,17 +1239,15 @@ class GlassViewEventHandler extends View.EventHandler {
                 stage.setInAllowedEventHandler(true);
             }
             QuantumToolkit.runWithoutRenderLock(() -> {
-                return AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                    if (scene.sceneListener != null) {
-                        scene.sceneListener.touchEventBegin(time, touchEventCount,
-                                isDirect,
-                                (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
-                                (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
-                                (modifiers & KeyEvent.MODIFIER_ALT) != 0,
-                                (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0);
-                    }
-                    return null;
-                }, scene.getAccessControlContext());
+                if (scene.sceneListener != null) {
+                    scene.sceneListener.touchEventBegin(time, touchEventCount,
+                            isDirect,
+                            (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
+                            (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
+                            (modifiers & KeyEvent.MODIFIER_ALT) != 0,
+                            (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0);
+                }
+                return null;
             });
         } finally {
             if (stage != null) {
@@ -1299,7 +1261,6 @@ class GlassViewEventHandler extends View.EventHandler {
         gestures.notifyBeginTouchEvent(time, modifiers, isDirect, touchEventCount);
     }
 
-    @SuppressWarnings("removal")
     @Override public void handleNextTouchEvent(
             View view, final long time, final int type, final long touchId,
             final int x, final int y, final int xAbs, final int yAbs)
@@ -1313,50 +1274,48 @@ class GlassViewEventHandler extends View.EventHandler {
                 stage.setInAllowedEventHandler(true);
             }
             QuantumToolkit.runWithoutRenderLock(() -> {
-                    return AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                    if (scene.sceneListener != null) {
-                        TouchPoint.State state;
-                        switch (type) {
-                            case TouchEvent.TOUCH_PRESSED:
-                                state = TouchPoint.State.PRESSED;
-                                break;
-                            case TouchEvent.TOUCH_MOVED:
-                                state = TouchPoint.State.MOVED;
-                                break;
-                            case TouchEvent.TOUCH_STILL:
-                                state = TouchPoint.State.STATIONARY;
-                                break;
-                            case TouchEvent.TOUCH_RELEASED:
-                                state = TouchPoint.State.RELEASED;
-                                break;
-                            default:
-                                throw new RuntimeException("Unknown touch state: " + type);
-                        }
-                        final Window w = view.getWindow();
-                        double pScaleX, pScaleY, spx, spy, sx, sy;
-                        if (w != null) {
-                            pScaleX = w.getPlatformScaleX();
-                            pScaleY = w.getPlatformScaleY();
-                            Screen scr = w.getScreen();
-                            if (scr != null) {
-                                spx = scr.getPlatformX();
-                                spy = scr.getPlatformY();
-                                sx = scr.getX();
-                                sy = scr.getY();
-                            } else {
-                                spx = spy = sx = sy = 0.0;
-                            }
+                if (scene.sceneListener != null) {
+                    TouchPoint.State state;
+                    switch (type) {
+                        case TouchEvent.TOUCH_PRESSED:
+                            state = TouchPoint.State.PRESSED;
+                            break;
+                        case TouchEvent.TOUCH_MOVED:
+                            state = TouchPoint.State.MOVED;
+                            break;
+                        case TouchEvent.TOUCH_STILL:
+                            state = TouchPoint.State.STATIONARY;
+                            break;
+                        case TouchEvent.TOUCH_RELEASED:
+                            state = TouchPoint.State.RELEASED;
+                            break;
+                        default:
+                            throw new RuntimeException("Unknown touch state: " + type);
+                    }
+                    final Window w = view.getWindow();
+                    double pScaleX, pScaleY, spx, spy, sx, sy;
+                    if (w != null) {
+                        pScaleX = w.getPlatformScaleX();
+                        pScaleY = w.getPlatformScaleY();
+                        Screen scr = w.getScreen();
+                        if (scr != null) {
+                            spx = scr.getPlatformX();
+                            spy = scr.getPlatformY();
+                            sx = scr.getX();
+                            sy = scr.getY();
                         } else {
-                            pScaleX = pScaleY = 1.0;
                             spx = spy = sx = sy = 0.0;
                         }
-                        scene.sceneListener.touchEventNext(state, touchId,
-                                x / pScaleX, y / pScaleY,
-                                sx + (xAbs - spx) / pScaleX,
-                                sy + (yAbs - spy) / pScaleY);
+                    } else {
+                        pScaleX = pScaleY = 1.0;
+                        spx = spy = sx = sy = 0.0;
                     }
-                    return null;
-                }, scene.getAccessControlContext());
+                    scene.sceneListener.touchEventNext(state, touchId,
+                            x / pScaleX, y / pScaleY,
+                            sx + (xAbs - spx) / pScaleX,
+                            sy + (yAbs - spy) / pScaleY);
+                }
+                return null;
             });
         } finally {
             if (stage != null) {
@@ -1370,7 +1329,6 @@ class GlassViewEventHandler extends View.EventHandler {
         gestures.notifyNextTouchEvent(time, type, touchId, x, y, xAbs, yAbs);
     }
 
-    @SuppressWarnings("removal")
     @Override public void handleEndTouchEvent(View view, long time) {
         if (PULSE_LOGGING_ENABLED) {
             PulseLogger.newInput("END_TOUCH_EVENT");
@@ -1381,12 +1339,10 @@ class GlassViewEventHandler extends View.EventHandler {
                 stage.setInAllowedEventHandler(true);
             }
             QuantumToolkit.runWithoutRenderLock(() -> {
-                return AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                    if (scene.sceneListener != null) {
-                        scene.sceneListener.touchEventEnd();
-                    }
-                    return null;
-                }, scene.getAccessControlContext());
+                if (scene.sceneListener != null) {
+                    scene.sceneListener.touchEventEnd();
+                }
+                return null;
             });
         } finally {
             if (stage != null) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassWindowEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassWindowEventHandler.java
@@ -33,11 +33,9 @@ import com.sun.glass.ui.Window.Level;
 
 import com.sun.javafx.tk.FocusCause;
 
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
+import java.util.function.Supplier;
 
-class GlassWindowEventHandler extends Window.EventHandler implements PrivilegedAction<Void> {
+class GlassWindowEventHandler extends Window.EventHandler implements Supplier<Void> {
 
     private final WindowStage stage;
 
@@ -49,7 +47,7 @@ class GlassWindowEventHandler extends Window.EventHandler implements PrivilegedA
     }
 
     @Override
-    public Void run() {
+    public Void get() {
         if (stage == null || stage.stageListener == null) {
             return null;
         }
@@ -155,31 +153,22 @@ class GlassWindowEventHandler extends Window.EventHandler implements PrivilegedA
         return null;
     }
 
-    @SuppressWarnings("removal")
     @Override
     public void handleLevelEvent(int level) {
         QuantumToolkit.runWithoutRenderLock(() -> {
-            AccessControlContext acc = stage.getAccessControlContext();
-            return AccessController.doPrivileged((PrivilegedAction<Void>)() -> {
-                stage.stageListener.changedAlwaysOnTop(level != Level.NORMAL);
-                return null;
-            } , acc);
+            stage.stageListener.changedAlwaysOnTop(level != Level.NORMAL);
+            return null;
         });
     }
 
-    @SuppressWarnings("removal")
     @Override
     public void handleWindowEvent(final Window window, final long time, final int type) {
         this.window = window;
         this.type = type;
 
-        QuantumToolkit.runWithoutRenderLock(() -> {
-            AccessControlContext acc = stage.getAccessControlContext();
-            return AccessController.doPrivileged(this, acc);
-        });
+        QuantumToolkit.runWithoutRenderLock(this);
     }
 
-    @SuppressWarnings("removal")
     @Override
     public void handleScreenChangedEvent(Window window, long time, Screen oldScreen, Screen newScreen) {
         GlassScene scene = stage.getScene();
@@ -192,11 +181,8 @@ class GlassWindowEventHandler extends Window.EventHandler implements PrivilegedA
         }
 
         QuantumToolkit.runWithoutRenderLock(() -> {
-            AccessControlContext acc = stage.getAccessControlContext();
-            return AccessController.doPrivileged((PrivilegedAction<Void>)() -> {
-                stage.stageListener.changedScreen(oldScreen, newScreen);
-                return null;
-            } , acc);
+            stage.stageListener.changedScreen(oldScreen, newScreen);
+            return null;
         });
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PerformanceLogger.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PerformanceLogger.java
@@ -85,28 +85,12 @@ public class PerformanceLogger {
     private static long baseTime;
 
     static {
-        @SuppressWarnings("removal")
-        String perfLoggingProp =
-            java.security.AccessController.doPrivileged(
-                    new java.security.PrivilegedAction<String>() {
-                        @Override
-                        public String run() {
-                            return System.getProperty("sun.perflog");
-                        }
-                    });
+        String perfLoggingProp = System.getProperty("sun.perflog");
         if (perfLoggingProp != null) {
             perfLoggingOn = true;
 
             // Check if we should use nanoTime
-            @SuppressWarnings("removal")
-            String perfNanoProp =
-                java.security.AccessController.doPrivileged(
-                    new java.security.PrivilegedAction<String>() {
-                        @Override
-                        public String run() {
-                            return System.getProperty("sun.perflog.nano");
-                        }
-                    });
+            String perfNanoProp = System.getProperty("sun.perflog.nano");
             if (perfNanoProp != null) {
                 useNanoTime = true;
             }
@@ -117,23 +101,15 @@ public class PerformanceLogger {
             }
             if (logFileName != null) {
                 if (logWriter == null) {
-                    @SuppressWarnings("removal")
-                    var dummy = java.security.AccessController.doPrivileged(
-                    new java.security.PrivilegedAction<Void>() {
-                        @Override
-                        public Void run() {
-                            try {
-                                File logFile = new File(logFileName);
-                                logFile.createNewFile();
-                                logWriter = new FileWriter(logFile);
-                            } catch (Exception e) {
-                                System.out.println(e + ": Creating logfile " +
-                                                   logFileName +
-                                                   ".  Log to console");
-                            }
-                            return null;
-                        }
-                    });
+                    try {
+                        File logFile = new File(logFileName);
+                        logFile.createNewFile();
+                        logWriter = new FileWriter(logFile);
+                    } catch (Exception e) {
+                        System.out.println(e + ": Creating logfile " +
+                                           logFileName +
+                                           ".  Log to console");
+                    }
                 }
             }
             if (logWriter == null) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PerformanceTrackerHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PerformanceTrackerHelper.java
@@ -43,25 +43,20 @@ abstract class PerformanceTrackerHelper {
     }
 
     private static PerformanceTrackerHelper createInstance() {
-        PerformanceTrackerHelper trackerImpl = null;
         try {
             if (PrismSettings.perfLog != null) {
-                final PerformanceTrackerHelper trackerImpl1 = new PerformanceTrackerDefaultImpl();
+                final PerformanceTrackerHelper trackerImpl = new PerformanceTrackerDefaultImpl();
                 if (PrismSettings.perfLogExitFlush) {
                     Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                        trackerImpl1.outputLog();
+                        trackerImpl.outputLog();
                     }));
                 }
-                trackerImpl = trackerImpl1;
+                return trackerImpl;
             }
         }catch (Throwable t) {
         }
 
-        if (trackerImpl == null) {
-            trackerImpl = new PerformanceTrackerDummyImpl();
-        }
-
-        return trackerImpl;
+        return new PerformanceTrackerDummyImpl();
     }
 
     public abstract void logEvent(final String s);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PerformanceTrackerHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PerformanceTrackerHelper.java
@@ -28,9 +28,6 @@ package com.sun.javafx.tk.quantum;
 import com.sun.javafx.tk.Toolkit;
 import com.sun.prism.impl.PrismSettings;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 /**
  * Class containing implementation for logging, and performance tracking.
  */
@@ -46,36 +43,19 @@ abstract class PerformanceTrackerHelper {
     }
 
     private static PerformanceTrackerHelper createInstance() {
-        @SuppressWarnings("removal")
-        PerformanceTrackerHelper trackerImpl = AccessController.doPrivileged(
-                new PrivilegedAction<PerformanceTrackerHelper>() {
-
-                    @Override
-                    public PerformanceTrackerHelper run() {
-                        try {
-                            if (PrismSettings.perfLog != null) {
-                                final PerformanceTrackerHelper trackerImpl =
-                                        new PerformanceTrackerDefaultImpl();
-
-                                if (PrismSettings.perfLogExitFlush) {
-                                    Runtime.getRuntime().addShutdownHook(
-                                            new Thread() {
-
-                                                @Override
-                                                public void run() {
-                                                    trackerImpl.outputLog();
-                                                }
-                                            });
-                                }
-
-                                return trackerImpl;
-                            }
-                        } catch (Throwable t) {
-                        }
-
-                        return null;
-                    }
-                });
+        PerformanceTrackerHelper trackerImpl = null;
+        try {
+            if (PrismSettings.perfLog != null) {
+                final PerformanceTrackerHelper trackerImpl1 = new PerformanceTrackerDefaultImpl();
+                if (PrismSettings.perfLogExitFlush) {
+                    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                        trackerImpl1.outputLog();
+                    }));
+                }
+                trackerImpl = trackerImpl1;
+            }
+        }catch (Throwable t) {
+        }
 
         if (trackerImpl == null) {
             trackerImpl = new PerformanceTrackerDummyImpl();
@@ -130,9 +110,7 @@ abstract class PerformanceTrackerHelper {
                 // Attempt to log launchTime, if not set already
                 if (PerformanceLogger.getStartTime() <= 0) {
                     // Standalone apps record launch time as sysprop
-                    @SuppressWarnings("removal")
-                    String launchTimeString = AccessController.doPrivileged(
-                            (PrivilegedAction<String>) () -> System.getProperty("launchTime"));
+                    String launchTimeString = System.getProperty("launchTime");
 
                     if (launchTimeString != null
                             && !launchTimeString.equals("")) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
@@ -61,8 +61,6 @@ import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -136,70 +134,58 @@ import java.util.Optional;
 
 public final class QuantumToolkit extends Toolkit {
 
-    @SuppressWarnings("removal")
-    public static final boolean verbose =
-            AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("quantum.verbose"));
+    public static final boolean verbose = Boolean.getBoolean("quantum.verbose");
 
-    @SuppressWarnings("removal")
-    public static final boolean pulseDebug =
-            AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("quantum.pulse"));
+    public static final boolean pulseDebug = Boolean.getBoolean("quantum.pulse");
 
-    @SuppressWarnings("removal")
-    private static final boolean multithreaded =
-            AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
-                // If it is not specified, or it is true, then it should
-                // be true. Otherwise it should be false.
-                String value = System.getProperty("quantum.multithreaded");
-                if (value == null) return true;
-                final boolean result = Boolean.parseBoolean(value);
-                if (verbose) {
-                    System.out.println(result ? "Multi-Threading Enabled" : "Multi-Threading Disabled");
-                }
-                return result;
-            });
+    private static final boolean multithreaded = initMultithreaded();
+    private static boolean initMultithreaded() {
+        // If it is not specified, or it is true, then it should
+        // be true. Otherwise it should be false.
+        String value = System.getProperty("quantum.multithreaded");
+        if (value == null) return true;
+        final boolean result = Boolean.parseBoolean(value);
+        if (verbose) {
+            System.out.println(result ? "Multi-Threading Enabled" : "Multi-Threading Disabled");
+        }
+        return result;
+    }
 
-    @SuppressWarnings("removal")
-    private static boolean debug =
-            AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("quantum.debug"));
+    private static boolean debug = Boolean.getBoolean("quantum.debug");
 
-    @SuppressWarnings("removal")
-    private static Integer pulseHZ =
-            AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Integer.getInteger("javafx.animation.pulse"));
+    private static Integer pulseHZ = Integer.getInteger("javafx.animation.pulse");
 
-    @SuppressWarnings("removal")
-    static final boolean liveResize =
-            AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
-                boolean isSWT = "swt".equals(System.getProperty("glass.platform"));
-                String result = (PlatformUtil.isMac() || PlatformUtil.isWindows()) && !isSWT ? "true" : "false";
-                return "true".equals(System.getProperty("javafx.live.resize", result));
-            });
+    static final boolean liveResize = initLiveResize();
+    private static final boolean initLiveResize() {
+        boolean isSWT = "swt".equals(System.getProperty("glass.platform"));
+        String result = (PlatformUtil.isMac() || PlatformUtil.isWindows()) && !isSWT ? "true" : "false";
+        return "true".equals(System.getProperty("javafx.live.resize", result));
+    }
 
-    @SuppressWarnings("removal")
-    static final boolean drawInPaint =
-            AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
-                boolean isSWT = "swt".equals(System.getProperty("glass.platform"));
-                String result = PlatformUtil.isMac() && isSWT ? "true" : "false";
-                return "true".equals(System.getProperty("javafx.draw.in.paint", result));});
+    static final boolean drawInPaint = initDrawInPaint();
+    static final boolean initDrawInPaint() {
+        boolean isSWT = "swt".equals(System.getProperty("glass.platform"));
+        String result = PlatformUtil.isMac() && isSWT ? "true" : "false";
+        return "true".equals(System.getProperty("javafx.draw.in.paint", result));
+    }
 
-    @SuppressWarnings("removal")
-    private static boolean singleThreaded =
-            AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
-                Boolean result = Boolean.getBoolean("quantum.singlethreaded");
-                if (/*verbose &&*/ result) {
-                    System.out.println("Warning: Single GUI Threadiong is enabled, FPS should be slower");
-                }
-                return result;
-            });
+    private static final boolean singleThreaded = initSingleThreaded();
+    private static boolean initSingleThreaded() {
+        Boolean result = Boolean.getBoolean("quantum.singlethreaded");
+        if (/*verbose &&*/ result) {
+            System.out.println("Warning: Single GUI Threadiong is enabled, FPS should be slower");
+        }
+        return result;
+    }
 
-    @SuppressWarnings("removal")
-    private static boolean noRenderJobs =
-            AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
-                Boolean result = Boolean.getBoolean("quantum.norenderjobs");
-                if (/*verbose &&*/ result) {
-                    System.out.println("Warning: Quantum will not submit render jobs, nothing should draw");
-                }
-                return result;
-            });
+    private static final boolean noRenderJobs = initNoRenderJobs();
+    private static boolean initNoRenderJobs() {
+        Boolean result = Boolean.getBoolean("quantum.norenderjobs");
+        if (/*verbose &&*/ result) {
+            System.out.println("Warning: Quantum will not submit render jobs, nothing should draw");
+        }
+        return result;
+    }
 
     private class PulseTask {
         private volatile boolean isRunning;
@@ -280,11 +266,7 @@ public final class QuantumToolkit extends Toolkit {
                 }
             }
         };
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            Runtime.getRuntime().addShutdownHook(shutdownHook);
-            return null;
-        });
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
         return true;
     }
 
@@ -876,17 +858,13 @@ public final class QuantumToolkit extends Toolkit {
         super.exit();
     }
 
-    @SuppressWarnings("removal")
     public void dispose() {
         if (toolkitRunning.compareAndSet(true, false)) {
             pulseTimer.stop();
             renderer.stopRenderer();
 
             try {
-                AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                    Runtime.getRuntime().removeShutdownHook(shutdownHook);
-                    return null;
-                });
+                Runtime.getRuntime().removeShutdownHook(shutdownHook);
             } catch (IllegalStateException ignore) {
                 // throw when shutdown hook already removed
             }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/RotateGestureRecognizer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/RotateGestureRecognizer.java
@@ -28,8 +28,6 @@ package com.sun.javafx.tk.quantum;
 import com.sun.glass.events.KeyEvent;
 import com.sun.glass.events.TouchEvent;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.Map;
 import javafx.util.Duration;
@@ -50,18 +48,14 @@ class RotateGestureRecognizer implements GestureRecognizer {
     private static double MAX_INITIAL_VELOCITY = 500;
     private static double ROTATION_INERTIA_MILLIS = 1500;
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            String s = System.getProperty("com.sun.javafx.gestures.rotate.threshold");
-            if (s != null) {
-                ROTATATION_THRESHOLD = Double.valueOf(s);
-            }
-            s = System.getProperty("com.sun.javafx.gestures.rotate.inertia");
-            if (s != null) {
-                ROTATION_INERTIA_ENABLED = Boolean.valueOf(s);
-            }
-            return null;
-        });
+        String s = System.getProperty("com.sun.javafx.gestures.rotate.threshold");
+        if (s != null) {
+            ROTATATION_THRESHOLD = Double.valueOf(s);
+        }
+        s = System.getProperty("com.sun.javafx.gestures.rotate.inertia");
+        if (s != null) {
+            ROTATION_INERTIA_ENABLED = Boolean.valueOf(s);
+        }
     }
 
     private RotateRecognitionState state = RotateRecognitionState.IDLE;
@@ -314,60 +308,48 @@ class RotateGestureRecognizer implements GestureRecognizer {
         }
     }
 
-    @SuppressWarnings("removal")
     private void sendRotateStartedEvent() {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            if (scene.sceneListener != null) {
-                scene.sceneListener.rotateEvent(RotateEvent.ROTATION_STARTED,
-                    0, 0,
-                    centerX, centerY,
-                    centerAbsX, centerAbsY,
-                    (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
-                    (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
-                    (modifiers & KeyEvent.MODIFIER_ALT) != 0,
-                    (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
-                    direct,
-                    false /*inertia*/);
-            }
-            return null;
-        }, scene.getAccessControlContext());
+        if (scene.sceneListener != null) {
+            scene.sceneListener.rotateEvent(RotateEvent.ROTATION_STARTED,
+                0, 0,
+                centerX, centerY,
+                centerAbsX, centerAbsY,
+                (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
+                (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
+                (modifiers & KeyEvent.MODIFIER_ALT) != 0,
+                (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
+                direct,
+                false /*inertia*/);
+        }
     }
 
-    @SuppressWarnings("removal")
     private void sendRotateEvent(boolean isInertia) {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            if (scene.sceneListener != null) {
-                scene.sceneListener.rotateEvent(RotateEvent.ROTATE,
-                    currentRotation, totalRotation,
-                    centerX, centerY,
-                    centerAbsX, centerAbsY,
-                    (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
-                    (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
-                    (modifiers & KeyEvent.MODIFIER_ALT) != 0,
-                    (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
-                    direct, isInertia);
-            }
-            return null;
-        }, scene.getAccessControlContext());
+        if (scene.sceneListener != null) {
+            scene.sceneListener.rotateEvent(RotateEvent.ROTATE,
+                currentRotation, totalRotation,
+                centerX, centerY,
+                centerAbsX, centerAbsY,
+                (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
+                (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
+                (modifiers & KeyEvent.MODIFIER_ALT) != 0,
+                (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
+                direct, isInertia);
+        }
     }
 
-    @SuppressWarnings("removal")
     private void sendRotateFinishedEvent() {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            if (scene.sceneListener != null) {
-                scene.sceneListener.rotateEvent(RotateEvent.ROTATION_FINISHED,
-                    0, totalRotation,
-                    centerX, centerY,
-                    centerAbsX, centerAbsY,
-                    (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
-                    (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
-                    (modifiers & KeyEvent.MODIFIER_ALT) != 0,
-                    (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
-                    direct,
-                    false /*inertia*/);
-            }
-            return null;
-        }, scene.getAccessControlContext());
+        if (scene.sceneListener != null) {
+            scene.sceneListener.rotateEvent(RotateEvent.ROTATION_FINISHED,
+                0, totalRotation,
+                centerX, centerY,
+                centerAbsX, centerAbsY,
+                (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
+                (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
+                (modifiers & KeyEvent.MODIFIER_ALT) != 0,
+                (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
+                direct,
+                false /*inertia*/);
+        }
     }
 
     public void params(int modifiers, boolean direct) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/ScrollGestureRecognizer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/ScrollGestureRecognizer.java
@@ -28,8 +28,6 @@ package com.sun.javafx.tk.quantum;
 import com.sun.glass.events.KeyEvent;
 import com.sun.glass.events.TouchEvent;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.Map;
 import javafx.util.Duration;
@@ -48,18 +46,14 @@ class ScrollGestureRecognizer implements GestureRecognizer {
     private static double MAX_INITIAL_VELOCITY = 1000;
     private static double SCROLL_INERTIA_MILLIS = 1500;
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            String s = System.getProperty("com.sun.javafx.gestures.scroll.threshold");
-            if (s != null) {
-                SCROLL_THRESHOLD = Double.valueOf(s);
-            }
-            s = System.getProperty("com.sun.javafx.gestures.scroll.inertia");
-            if (s != null) {
-                SCROLL_INERTIA_ENABLED = Boolean.valueOf(s);
-            }
-            return null;
-        });
+        String s = System.getProperty("com.sun.javafx.gestures.scroll.threshold");
+        if (s != null) {
+            SCROLL_THRESHOLD = Double.valueOf(s);
+        }
+        s = System.getProperty("com.sun.javafx.gestures.scroll.inertia");
+        if (s != null) {
+            SCROLL_INERTIA_ENABLED = Boolean.valueOf(s);
+        }
     }
 
     private ViewScene scene;
@@ -260,70 +254,58 @@ class ScrollGestureRecognizer implements GestureRecognizer {
         }
     }
 
-    @SuppressWarnings("removal")
     private void sendScrollStartedEvent(double xAbs, double yAbs, int touchCount) {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            if (scene.sceneListener != null) {
-                scene.sceneListener.scrollEvent(ScrollEvent.SCROLL_STARTED,
-                    0, 0,
-                    0, 0,
-                    1 /*xMultiplier*/, 1 /*yMultiplier*/,
-                    touchCount,
-                    0 /*scrollTextX*/, 0 /*scrollTextY*/,
-                    0 /*defaultTextX*/, 0 /*defaultTextY*/,
-                    centerX, centerY, xAbs, yAbs,
-                    (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
-                    (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
-                    (modifiers & KeyEvent.MODIFIER_ALT) != 0,
-                    (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
-                    direct, false /*inertia*/);
-            }
-            return null;
-        }, scene.getAccessControlContext());
+        if (scene.sceneListener != null) {
+            scene.sceneListener.scrollEvent(ScrollEvent.SCROLL_STARTED,
+                0, 0,
+                0, 0,
+                1 /*xMultiplier*/, 1 /*yMultiplier*/,
+                touchCount,
+                0 /*scrollTextX*/, 0 /*scrollTextY*/,
+                0 /*defaultTextX*/, 0 /*defaultTextY*/,
+                centerX, centerY, xAbs, yAbs,
+                (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
+                (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
+                (modifiers & KeyEvent.MODIFIER_ALT) != 0,
+                (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
+                direct, false /*inertia*/);
+        }
     }
 
-    @SuppressWarnings("removal")
     private void sendScrollEvent(boolean isInertia, double xAbs, double yAbs, int touchCount) {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            if (scene.sceneListener != null) {
-                scene.sceneListener.scrollEvent(ScrollEvent.SCROLL,
-                    deltaX, deltaY,
-                    totalDeltaX, totalDeltaY,
-                    1 /*xMultiplier*/, 1 /*yMultiplier*/,
-                    touchCount,
-                    0 /*scrollTextX*/, 0 /*scrollTextY*/,
-                    0 /*defaultTextX*/, 0 /*defaultTextY*/,
-                    centerX, centerY, xAbs, yAbs,
-                    (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
-                    (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
-                    (modifiers & KeyEvent.MODIFIER_ALT) != 0,
-                    (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
-                    direct, isInertia);
-            }
-            return null;
-        }, scene.getAccessControlContext());
+        if (scene.sceneListener != null) {
+            scene.sceneListener.scrollEvent(ScrollEvent.SCROLL,
+                deltaX, deltaY,
+                totalDeltaX, totalDeltaY,
+                1 /*xMultiplier*/, 1 /*yMultiplier*/,
+                touchCount,
+                0 /*scrollTextX*/, 0 /*scrollTextY*/,
+                0 /*defaultTextX*/, 0 /*defaultTextY*/,
+                centerX, centerY, xAbs, yAbs,
+                (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
+                (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
+                (modifiers & KeyEvent.MODIFIER_ALT) != 0,
+                (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
+                direct, isInertia);
+        }
     }
 
-    @SuppressWarnings("removal")
     private void sendScrollFinishedEvent(double xAbs, double yAbs, int touchCount) {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            if (scene.sceneListener != null) {
-                scene.sceneListener.scrollEvent(ScrollEvent.SCROLL_FINISHED,
-                    0, 0,
-                    totalDeltaX, totalDeltaY,
-                    1 /*xMultiplier*/, 1 /*yMultiplier*/,
-                    touchCount,
-                    0 /*scrollTextX*/, 0 /*scrollTextY*/,
-                    0 /*defaultTextX*/, 0 /*defaultTextY*/,
-                    centerX, centerY, xAbs, yAbs,
-                    (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
-                    (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
-                    (modifiers & KeyEvent.MODIFIER_ALT) != 0,
-                    (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
-                    direct, false /*inertia*/);
-            }
-            return null;
-        }, scene.getAccessControlContext());
+        if (scene.sceneListener != null) {
+            scene.sceneListener.scrollEvent(ScrollEvent.SCROLL_FINISHED,
+                0, 0,
+                totalDeltaX, totalDeltaY,
+                1 /*xMultiplier*/, 1 /*yMultiplier*/,
+                touchCount,
+                0 /*scrollTextX*/, 0 /*scrollTextY*/,
+                0 /*defaultTextX*/, 0 /*defaultTextY*/,
+                centerX, centerY, xAbs, yAbs,
+                (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
+                (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
+                (modifiers & KeyEvent.MODIFIER_ALT) != 0,
+                (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
+                direct, false /*inertia*/);
+        }
     }
 
     public void params(int modifiers, boolean direct) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/SwipeGestureRecognizer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/SwipeGestureRecognizer.java
@@ -28,8 +28,6 @@ package com.sun.javafx.tk.quantum;
 import com.sun.glass.events.KeyEvent;
 import com.sun.glass.events.TouchEvent;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.Map;
 import javafx.event.EventType;
@@ -148,7 +146,6 @@ class SwipeGestureRecognizer implements GestureRecognizer {
         }
     }
 
-    @SuppressWarnings("removal")
     private void handleSwipeType(final EventType<SwipeEvent> swipeType,
             final CenterComputer cc, final int touchCount, final int modifiers, final boolean isDirect)
     {
@@ -159,19 +156,16 @@ class SwipeGestureRecognizer implements GestureRecognizer {
             System.err.println("handleSwipeType swipeType=" + swipeType);
         }
 
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            if (scene.sceneListener != null) {
-                scene.sceneListener.swipeEvent(swipeType, touchCount,
-                    cc.getX(), cc.getY(),
-                    cc.getAbsX(), cc.getAbsY(),
-                    (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
-                    (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
-                    (modifiers & KeyEvent.MODIFIER_ALT) != 0,
-                    (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
-                    isDirect);
-            }
-            return null;
-        }, scene.getAccessControlContext());
+        if (scene.sceneListener != null) {
+            scene.sceneListener.swipeEvent(swipeType, touchCount,
+                cc.getX(), cc.getY(),
+                cc.getAbsX(), cc.getAbsY(),
+                (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
+                (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
+                (modifiers & KeyEvent.MODIFIER_ALT) != 0,
+                (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
+                isDirect);
+        }
     }
 
     private static class CenterComputer {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
@@ -26,9 +26,7 @@
 package com.sun.javafx.tk.quantum;
 
 import java.nio.ByteBuffer;
-import java.security.AccessController;
 import java.security.Permission;
-import java.security.PrivilegedAction;
 import java.security.AccessControlContext;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -740,7 +738,6 @@ public class WindowStage extends GlassStage {
         }
     }
 
-    @SuppressWarnings("removal")
     void fullscreenChanged(final boolean fs) {
         if (!fs) {
             if (activeFSWindow.compareAndSet(this, null)) {
@@ -750,12 +747,9 @@ public class WindowStage extends GlassStage {
             isInFullScreen = true;
             activeFSWindow.set(this);
         }
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            if (stageListener != null) {
-                stageListener.changedFullscreen(fs);
-            }
-            return null;
-        }, getAccessControlContext());
+        if (stageListener != null) {
+            stageListener.changedFullscreen(fs);
+        }
     }
 
     @Override public void toBack() {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/ZoomGestureRecognizer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/ZoomGestureRecognizer.java
@@ -28,8 +28,6 @@ package com.sun.javafx.tk.quantum;
 import com.sun.glass.events.KeyEvent;
 import com.sun.glass.events.TouchEvent;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.Map;
 import javafx.util.Duration;
@@ -52,18 +50,14 @@ class ZoomGestureRecognizer implements GestureRecognizer {
     private static double MAX_ZOOM_OUT_FACTOR = 0.1;
 
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            String s = System.getProperty("com.sun.javafx.gestures.zoom.threshold");
-            if (s != null) {
-                ZOOM_FACTOR_THRESHOLD = Double.valueOf(s);
-            }
-            s = System.getProperty("com.sun.javafx.gestures.zoom.inertia");
-            if (s != null) {
-                ZOOM_INERTIA_ENABLED = Boolean.valueOf(s);
-            }
-            return null;
-        });
+        String s = System.getProperty("com.sun.javafx.gestures.zoom.threshold");
+        if (s != null) {
+            ZOOM_FACTOR_THRESHOLD = Double.valueOf(s);
+        }
+        s = System.getProperty("com.sun.javafx.gestures.zoom.inertia");
+        if (s != null) {
+            ZOOM_INERTIA_ENABLED = Boolean.valueOf(s);
+        }
     }
 
     private ViewScene scene;
@@ -288,60 +282,48 @@ class ZoomGestureRecognizer implements GestureRecognizer {
         }
     }
 
-    @SuppressWarnings("removal")
     private void sendZoomStartedEvent() {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            if (scene.sceneListener != null) {
-                scene.sceneListener.zoomEvent(ZoomEvent.ZOOM_STARTED,
-                    1, 1,
-                    centerX, centerY,
-                    centerAbsX, centerAbsY,
-                    (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
-                    (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
-                    (modifiers & KeyEvent.MODIFIER_ALT) != 0,
-                    (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
-                    direct,
-                    false /*inertia*/);
-            }
-            return null;
-        }, scene.getAccessControlContext());
+        if (scene.sceneListener != null) {
+            scene.sceneListener.zoomEvent(ZoomEvent.ZOOM_STARTED,
+                1, 1,
+                centerX, centerY,
+                centerAbsX, centerAbsY,
+                (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
+                (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
+                (modifiers & KeyEvent.MODIFIER_ALT) != 0,
+                (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
+                direct,
+                false /*inertia*/);
+        }
     }
 
-    @SuppressWarnings("removal")
     private void sendZoomEvent(boolean isInertia) {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            if (scene.sceneListener != null) {
-                scene.sceneListener.zoomEvent(ZoomEvent.ZOOM,
-                    zoomFactor, totalZoomFactor,
-                    centerX, centerY,
-                    centerAbsX, centerAbsY,
-                    (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
-                    (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
-                    (modifiers & KeyEvent.MODIFIER_ALT) != 0,
-                    (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
-                    direct, isInertia);
-            }
-            return null;
-        }, scene.getAccessControlContext());
+        if (scene.sceneListener != null) {
+            scene.sceneListener.zoomEvent(ZoomEvent.ZOOM,
+                zoomFactor, totalZoomFactor,
+                centerX, centerY,
+                centerAbsX, centerAbsY,
+                (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
+                (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
+                (modifiers & KeyEvent.MODIFIER_ALT) != 0,
+                (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
+                direct, isInertia);
+        }
     }
 
-    @SuppressWarnings("removal")
     private void sendZoomFinishedEvent() {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            if (scene.sceneListener != null) {
-                scene.sceneListener.zoomEvent(ZoomEvent.ZOOM_FINISHED,
-                    1, totalZoomFactor,
-                    centerX, centerY,
-                    centerAbsX, centerAbsY,
-                    (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
-                    (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
-                    (modifiers & KeyEvent.MODIFIER_ALT) != 0,
-                    (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
-                    direct,
-                    false /*inertia*/);
-            }
-            return null;
-        }, scene.getAccessControlContext());
+        if (scene.sceneListener != null) {
+            scene.sceneListener.zoomEvent(ZoomEvent.ZOOM_FINISHED,
+                1, totalZoomFactor,
+                centerX, centerY,
+                centerAbsX, centerAbsY,
+                (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
+                (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
+                (modifiers & KeyEvent.MODIFIER_ALT) != 0,
+                (modifiers & KeyEvent.MODIFIER_WINDOWS) != 0,
+                direct,
+                false /*inertia*/);
+        }
     }
 
     public void params(int modifiers, boolean direct) {


### PR DESCRIPTION
Temporary Draft PR in my personal fork to show the diffs between this branch and the `8341090-remove-sm` branch, on which this branch is based.

@andy-goryachev-oracle @lukostyra @arapte @jayathirthrao 

This is ready for you to take an initial look at. Note that it is targeted to a branch in my repo, so once I integrate [JDK-8341090](https://bugs.openjdk.org/browse/JDK-8341090), I'll closed this Draft PR and open a PR in the openjdk/jfx repo.

Feel free to ask questions about any of this, although I'm not certain you'll be able to comment in this PR (ping me offline if not).

Here is a quick overview of what I did:

1. Changed all simple cases of `doPrivileged((PrivilegedAction<T>) () -> LAMBDA)` to `LAMBDA`, removing the `@SuppressWarnings("removal")` if possible. In case of an unused or unneeded local variable, I removed the local variable.
2. Remove unused `AccessControlContext` variables (for those whose only use was passing into a doPrivileged call that is now gone).
3. Removed all `@SuppressWarnings("removal")` annotations that were unneeded after the removed doPrivileged calls. In some cases there are annotations on a method or class. Those can only be removed if the doPrivileged calls were the only use of deprecated SM API in that method or class.
4. Remove unused imports.

There were a couple of things I highlighted inline that are worth noting, so look at the inline comments (either in the diffs or below this Description).

Finally, here are a few "best practices" that I tried to follow, and would ask others to follow when doing their piece of this. The idea is to reduce the cognitive load on the reviewers. It might take you a couple extra minutes, but will save time during the review:

* When removing the doPrivileged calls, please do the minimum amount of reformatting necessary to properly indent the body of the doPrivileged after it is removed. For example, don't wholesale reformat a method (or worse, an entire class) just because a couple doPrivileged calls are removed.
* Please try to not reorder the import statements when removing unused imports.